### PR TITLE
set default FirewallVersion to v1.1.1

### DIFF
--- a/templates/entrypoint-existing-vpc.template.yaml
+++ b/templates/entrypoint-existing-vpc.template.yaml
@@ -383,7 +383,7 @@ Parameters:
 
   FirewallVersion:
     Type: String
-    Default: v1.1.0
+    Default: v1.1.1
     AllowedPattern: ".+"
     Description: Helm chart version of the product.
 

--- a/templates/entrypoint-new-vpc.template.yaml
+++ b/templates/entrypoint-new-vpc.template.yaml
@@ -397,7 +397,7 @@ Parameters:
 
   FirewallVersion:
     Type: String
-    Default: v1.1.0
+    Default: v1.1.1
     AllowedPattern: ".+"
     Description: Helm chart version of the product.
 

--- a/templates/sfcn.template.yaml
+++ b/templates/sfcn.template.yaml
@@ -213,7 +213,7 @@ Parameters:
 
   FirewallVersion:
     Type: String
-    Default: v1.1.0
+    Default: v1.1.1
     AllowedPattern: ".+"
     Description: Helm chart version of the product.
 


### PR DESCRIPTION
The current SFCN version in AWS marketplace is v1.1.1, so v1.1.0 should no longer be referenced


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
